### PR TITLE
Fix sdimg target's bootgen invocation so boot.bin is actually produced

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -259,6 +259,7 @@ endif
 	mkimage -A arm -T ramdisk -C gzip -d $(SDIMGDIR)/ramdisk.image.gz $(SDIMGDIR)/uramdisk.image.gz
 	touch 	$(SDIMGDIR)/boot.bif
 	echo "img : {[bootloader] $(SDIMGDIR)/fsbl.elf  $(SDIMGDIR)/system_top.bit  $(SDIMGDIR)/u-boot.elf}" >  $(SDIMGDIR)/boot.bif
+	rm -f $(SDIMGDIR)/BOOT.bin
 	bash -c "source $(VIVADO_SETTINGS) && bootgen -image $(SDIMGDIR)/boot.bif -w -o $(SDIMGDIR)/BOOT.bin"
 	#rm $(SDIMGDIR)/fsbl.elf
 	#rm $(SDIMGDIR)/system_top.bit

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -259,7 +259,7 @@ endif
 	mkimage -A arm -T ramdisk -C gzip -d $(SDIMGDIR)/ramdisk.image.gz $(SDIMGDIR)/uramdisk.image.gz
 	touch 	$(SDIMGDIR)/boot.bif
 	echo "img : {[bootloader] $(SDIMGDIR)/fsbl.elf  $(SDIMGDIR)/system_top.bit  $(SDIMGDIR)/u-boot.elf}" >  $(SDIMGDIR)/boot.bif
-	bootgen -image $(SDIMGDIR)/boot.bif -w -o i $(SDIMGDIR)/BOOT.bin
+	bash -c "source $(VIVADO_SETTINGS) && bootgen -image $(SDIMGDIR)/boot.bif -w -o $(SDIMGDIR)/BOOT.bin"
 	#rm $(SDIMGDIR)/fsbl.elf
 	#rm $(SDIMGDIR)/system_top.bit
 	#rm $(SDIMGDIR)/u-boot.elf


### PR DESCRIPTION
## Fix `sdimg` target's bootgen invocation so `BOOT.bin` is actually produced

Buckle up this was weird!

### Summary

The `make PLATFORM=libre sdimg` target silently fails to produce `build/sdimg/BOOT.bin` because of a syntax error in the bootgen call at `firmware/Makefile:262`. Every preceding step populates `build/sdimg/` with the correct inputs. We get FSBL, bitstream, u-boot, devicetree, kernel, ramdisk, `uEnv.txt`, and `boot.bif`.  But bootgen itself never writes its output. This PR is a one-line fix plus a defensive `rm`. I used google, gemini, and Claude to figure this out. Makefiles are not an area I'm especially good at, but it's a procedural sort of deal, so I tackled it. 

### Symptom

After running `make PLATFORM=libre && make PLATFORM=libre sdimg` on a sparkly clean tree from our recent tx_sample_scale PR merge, `build/sdimg/` contains every component of an SD card image *except* `BOOT.bin`. Booting from such a card on a Zynq produces no console, no SSH, no web UI, no nothing good. The platform halts at the BootROM stage because there's nothing for it to load. This is a super fresh main-branch LibreSDR build immediately after the `tx_sample_scale` merge.

### Root cause

Line 262 of the Makefile currently reads:

```make
bootgen -image $(SDIMGDIR)/boot.bif -w -o i $(SDIMGDIR)/BOOT.bin
```

Two problems that I found out are going on:

1. **`-o i <filename>` turns out to be invalid syntax.** Xilinx bootgen's `-o` flag takes a single argument: the output filename. The bare `i` between `-o` and the path is parsed *as* the output filename, and the real path becomes a positional argument that bootgen rejects. The command fails before writing any usable file. Holy crap. OOps.

2. **No Vivado settings sourcing.** The recipe assumes `bootgen` is on `PATH`, which is only true if the caller manually sourced `settings64.sh` before invoking `make`. That *is* actually what is instructed in the README.md. The companion recipe for the lowercase `build/boot.bin` (line 207) wraps its bootgen call in `bash -c "source $(VIVADO_SETTINGS) && ..."` for exactly this reason; the `sdimg` recipe should match.

Ok now this should have happened. But if it doesn't, 2022.2 is called anyway, and nothing appears to be wrong if you just don't do it, or assume that yet another terminal window already has 2022.2 Vivado sourced. 

Compounding the silent-failure behavior: the recipe does not remove any pre-existing `BOOT.bin` before invoking bootgen!!! A stale `BOOT.bin` from an earlier successful build masks the failure, and `make sdimg` appears to succeed until a `clean-build` removes the staleness. This is what made the bug invisible until now!!!

### Fix (thanks mainly to a tutorial session with Claude)

```diff
-	bootgen -image $(SDIMGDIR)/boot.bif -w -o i $(SDIMGDIR)/BOOT.bin
+	rm -f $(SDIMGDIR)/BOOT.bin
+	bash -c "source $(VIVADO_SETTINGS) && bootgen -image $(SDIMGDIR)/boot.bif -w -o $(SDIMGDIR)/BOOT.bin"
```

Three changes, one line: drop the bogus `i`, add Vivado settings sourcing to mirror line 207 just in case, and `rm -f` any stale output before regenerating so future bootgen failures are loud rather than silent. In other words, if something is wrong, it doesn't proceed. 

### Verification

On a tree with the existing recipe, `make sdimg` runs to completion but leaves no `BOOT.bin`:

```
$ ls build/sdimg/BOOT.bin
ls: cannot access 'build/sdimg/BOOT.bin': No such file or directory
```

Manually invoking bootgen with the corrected syntax (equivalent to what this patch does):

```
$ (cd firmware && bootgen -image build/sdimg/boot.bif -w -o build/sdimg/BOOT.bin)
****** Xilinx Bootgen v2022.2.0
[WARNING]: Partition fsbl.elf.0 range is overlapped with partition system_top.bit.0 memory range
[INFO]   : Bootimage generated successfully

$ ls -la firmware/build/sdimg/BOOT.bin
-rw-rw-r-- 1 user user 3098436 ... build/sdimg/BOOT.bin
```

The `[WARNING]` about partition range overlap is actually ok. It appears for any Zynq boot image that combines FSBL + bitstream + u-boot, because bootgen's static load-address analysis can't distinguish OCM, PCAP-configured fabric, and DDR destinations. I don't know how to fix this and no one else out there seems to be worried about it. Maybe we can tackle this if we get bored. 

### Scope and risk

The `sdimg` recipe is shared across pluto / plutoplus / e200 / libre, but in practice only libre ships an SD-card form factor through this path; the other platforms boot from onboard flash via DFU/`.frm`. There is no working SD-card flow this change can regress or mess up. We are good. 

### How this was discovered

During LibreSDR firmware bring-up immediately after merging `tx_sample_scale` to `main`. The fresh main build produced an unbootable SD card, which initially looked like a missing source change from the merge. SHA-256 comparison of the two source trees confirmed they are byte-identical (461 files, every hash matches), which moved the investigation from "what code changed?" to "what build step silently broke?". The presence of all upstream artifacts (`system_top.xsa`, `system_top.bit`, `fsbl.elf`, `u-boot.elf`, lowercase `boot.bin`) in `build/`, combined with the absence of only `build/sdimg/BOOT.bin`, localized the failure to the final bootgen call. Manual reproduction with corrected syntax produced a valid 3,098,436-byte BOOT.bin that booted normally. And, digging in found a (conservative, protection-oriented) fix. 